### PR TITLE
Add pull request template file

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+---
+assignees:
+ - abungay
+ - Hajar1
+ - zaidoon1
+ - LauraMachado21
+ - MohamedZalat
+---
+## Description of changes
+Please provide a meaningful description of the changes introduced by this pull request here.
+
+## Screenshots (If Applicable)
+N/A
+
+## Checklist
+- [ ] I have unit tested my code.
+- [ ] I have integration tested my code.
+- [ ] All new and existing tests passed.
+- [ ] I have [updated the diagrams](https://github.com/amazin-team/Amazin-online-bookstore/wiki/Updating-the-diagrams) ModelsUMLClassDiagram and EntityRelationshipDiagram (if necessary).


### PR DESCRIPTION
Will help us remember to do routine tasks for each PR and have a standardized format.

Note: the assignee's section at the start of the template is YAML front matter that should automatically set the reviewers of the PR to all team members. After this is merged in if this doesn't work as expected we can remove that front matter section from the template.