### PR TITLE
remove YAML frontmatter from PR template - not working

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,3 @@
----
-assignees:
- - abungay
- - Hajar1
- - zaidoon1
- - LauraMachado21
- - MohamedZalat
----
 ## Description of changes
 Please provide a meaningful description of the changes introduced by this pull request here.
 


### PR DESCRIPTION
## Description of changes
Fix for PR #18 to remove YAML front-matter since it is noticed when testing to try to add a new PR that it does not add these users as the assignees to the PR as it should do so we don't need this part.

## Screenshots (If Applicable)
N/A

## Checklist
- [x] I have unit tested my code.
- [x] I have integration tested my code.
- [x] All new and existing tests passed.
- [x] I have [updated the diagrams](https://github.com/amazin-team/Amazin-online-bookstore/wiki/Updating-the-diagrams) ModelsUMLClassDiagram and EntityRelationshipDiagram (if necessary).
