### PR TITLE
feat(database): book repository is now using postgresql instead of h2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,9 +42,10 @@
             <version>RELEASE</version>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>RELEASE</version>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.2.1</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/amazin/model/Book.java
+++ b/src/main/java/amazin/model/Book.java
@@ -12,38 +12,47 @@ import org.hibernate.search.annotations.Indexed;
 
 @Entity
 @Indexed
+@Table(name="book")
 public class Book {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(name = "id", updatable = false, nullable = false)
-    private Long id = null;
+    @Column(name = "book_id", updatable = false, nullable = false)
+    private Long id;
     @NotNull
     @Size(min = 2, message = "Book name should have at least 2 characters")
+    @Column(name="book_name")
     @Field
     private String name;
     @NotNull
     @Size(min = 2, message = "Book description should have at least 2 characters")
+    @Column(name="book_description")
     @Field
     private String description;
     @NotNull
     @Size(min = 13, max = 13, message = "ISBN should be 13 characters long") // ISBN is a 13 digit number
+    @Column(name="book_isbn")
     @Field
     private String ISBN;
+    @Column(name="book_picture")
     @Field
     private String picture;
     @NotNull
     @Size(min = 2, message = "Book author should have at least 2 characters")
+    @Column(name="book_author")
     @Field
     private String author;
     @NotNull
     @Size(min = 1, message = "Book publisher should have at least 2 characters")
+    @Column(name="book_publisher")
     @Field
     private String publisher;
     @Min(0)
+    @Column(name="book_inventory")
     @Field
     private int inventory;
     @Min(0)
+    @Column(name="book_price")
     @Field
     private double price;
 

--- a/src/main/java/amazin/repository/BookRepository.java
+++ b/src/main/java/amazin/repository/BookRepository.java
@@ -1,10 +1,10 @@
 package amazin.repository;
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 import amazin.model.Book;
 
 @RepositoryRestResource(collectionResourceRel = "book", path = "book.json")
-public interface BookRepository extends CrudRepository<Book, Long> {
+public interface BookRepository extends JpaRepository<Book, Long> {
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,14 @@ spring.jpa.properties.hibernate.search.default.directory_provider = filesystem
 # Using the filesystem DirectoryProvider you also have to specify the default
 # base directory for all indexes 
 spring.jpa.properties.hibernate.search.default.indexBase = searchIndex
+
+# Database variables setup.
+spring.jpa.database = POSTGRESQL
+spring.datasource.url = ${JDBC_DATABASE_URL}
+spring.datasource.username = ${JDBC_DATABASE_USERNAME}
+spring.datasource.password = ${JDBC_DATABASE_PASSWORD}
+spring.datasource.driver-class-name = org.postgresql.Driver
+spring.jpa.show-sql = true
+spring.jpa.generate-ddl = true
+spring.jpa.hibernate.ddl-auto = update
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation = true


### PR DESCRIPTION
This allows us to persist books between deployments without having to re-add books.

## Description of changes
Changed database from h2 to postgresql. The username, url and password of the database is based upon the environment variables of heroku.

## Screenshots (If Applicable)
N/A

## Checklist
- [x] I have unit tested my code.
- [x] I have integration tested my code.
- [x] All new and existing tests passed.
- [ ] I have [updated the diagrams](https://github.com/amazin-team/Amazin-online-bookstore/wiki/Updating-the-diagrams) ModelsUMLClassDiagram and EntityRelationshipDiagram (if necessary).
