### PR TITLE
bug-fix/BookController: error message not displaying

### DIFF
--- a/src/main/java/amazin/controller/BookController.java
+++ b/src/main/java/amazin/controller/BookController.java
@@ -47,7 +47,8 @@ public class BookController {
     }
 
     @PostMapping("/addbook")
-    public String addBook(@Valid @ModelAttribute Book book, BindingResult result, RedirectAttributes attributes) {
+    public String addBook(@Valid @ModelAttribute(MODEL_ATTRIBUTE_BOOK) Book book, BindingResult result,
+            RedirectAttributes attributes) {
         if (result.hasErrors()) {
             return VIEW_CREATE_BOOK;
         }
@@ -72,8 +73,8 @@ public class BookController {
     }
 
     @PostMapping("/update/{id}")
-    public String updateBook(@PathVariable("id") Long id, @Valid Book book, BindingResult result,
-            RedirectAttributes attributes) {
+    public String updateBook(@PathVariable("id") Long id, @Valid @ModelAttribute(MODEL_ATTRIBUTE_BOOK) Book book,
+            BindingResult result, RedirectAttributes attributes) {
         if (result.hasErrors()) {
             book.setId(id);
             return VIEW_UPDATE_BOOK;

--- a/src/main/resources/templates/update-book.html
+++ b/src/main/resources/templates/update-book.html
@@ -9,42 +9,42 @@
             <p>
                 <label for="name">Name:</label>
                 <input id="name" type="text" minlength="2" th:field="*{name}">
-                <span class="error" th:if="${#fields.hasErrors('name')}" th:errors="*{name}"></span>
+                <span class="error-input" th:if="${#fields.hasErrors('name')}" th:errors="*{name}"></span>
             </p>
             <p>
                 <label for="description">Description:</label>
                 <textarea id="description" name="description" minlength="2" th:field="*{description}" cols="17" rows="5"></textarea>
-                <span class="error" th:if="${#fields.hasErrors('description')}" th:errors="*{description}"></span>
+                <span class="error-input" th:if="${#fields.hasErrors('description')}" th:errors="*{description}"></span>
             </p>
             <p>
                 <label for="ISBN">ISBN:</label>
                 <input id="ISBN" type="text" minlength="13" maxlength="13" th:field="*{ISBN}">
-                <span class="error" th:if="${#fields.hasErrors('ISBN')}" th:errors="*{ISBN}"></span>
+                <span class="error-input" th:if="${#fields.hasErrors('ISBN')}" th:errors="*{ISBN}"></span>
             </p>
             <p>
                 <label for="picture">Picture:</label>
                 <input id="picture" type="file" th:field="*{picture}">
-                <span class="error" th:if="${#fields.hasErrors('picture')}" th:errors="*{picture}"></span>
+                <span class="error-input" th:if="${#fields.hasErrors('picture')}" th:errors="*{picture}"></span>
             </p>
             <p>
                 <label for="author">Author:</label>
                 <input id="author" type="text" minlength="2" th:field="*{author}">
-                <span class="error" th:if="${#fields.hasErrors('author')}" th:errors="*{author}"></span>
+                <span class="error-input" th:if="${#fields.hasErrors('author')}" th:errors="*{author}"></span>
             </p>
             <p>
                 <label for="publisher">Publisher:</label>
                 <input id="publisher" type="text" minlength="2" th:field="*{publisher}">
-                <span class="error" th:if="${#fields.hasErrors('publisher')}" th:errors="*{publisher}"></span>
+                <span class="error-input" th:if="${#fields.hasErrors('publisher')}" th:errors="*{publisher}"></span>
             </p>
             <p>
                 <label for="inventory">Inventory:</label>
                 <input id="inventory" type="number" min="0" th:field="*{inventory}">
-                <span class="error" th:if="${#fields.hasErrors('inventory')}" th:errors="*{inventory}"></span>
+                <span class="error-input" th:if="${#fields.hasErrors('inventory')}" th:errors="*{inventory}"></span>
             </p>
             <p>
                 <label for="price">Price:</label>
                 <input id="price" type="number" step="0.01" min="0" th:field="*{price}">
-                <span class="error" th:if="${#fields.hasErrors('price')}" th:errors="*{price}"></span>
+                <span class="error-input" th:if="${#fields.hasErrors('price')}" th:errors="*{price}"></span>
             </p>
             <p><input id="submit" type="submit" value="Update Book" /> <input type="reset" value="Reset" /></p>
         </form>


### PR DESCRIPTION
## Description of changes
This fixes the issue with errors not displaying when an invalid input is enterd in one of the fields when the user is creating/ updating a book. Also, the styling for erros was updated in previous commit for creating a book but not for updating a book. This has now been fixed.

Fixes #66 

## Screenshots (If Applicable)
N/A

## Checklist
- [ ] I have unit tested my code.
- [ ] I have integration tested my code.
- [X] All new and existing tests passed.
- [ ] I have [updated the diagrams](https://github.com/amazin-team/Amazin-online-bookstore/wiki/Updating-the-diagrams) ModelsUMLClassDiagram and EntityRelationshipDiagram (if necessary).
