### PR TITLE
Fix/Email Validation Regex

### DIFF
--- a/src/main/java/amazin/model/User.java
+++ b/src/main/java/amazin/model/User.java
@@ -28,7 +28,7 @@ public class User {
     @Field
     private String lastName;
     @NotNull
-    @Pattern(regexp = "^\\w+@[a-zA-Z_]+?\\.[a-zA-Z]{2,3}$", message = "Not a valid email address")
+    @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "Not a valid email address")
     @Field
     @Column(unique = true, name="user_email")
     private String email;


### PR DESCRIPTION
## Issues
Fixes #77 

## Description of changes
Email regex on the backend was modified to accept emails such as johnsmith@cmail.carleton.ca since sub domain names e.g. "cmail.carleton.ca" were failing with the validation message "Not a valid email address".

## Screenshots (If Applicable)
N/A

## Checklist
- [ ] I have unit tested my code.
- [ ] I have integration tested my code.
- [x] All new and existing tests passed.
- [ ] I have [updated the diagrams](https://github.com/amazin-team/Amazin-online-bookstore/wiki/Updating-the-diagrams) ModelsUMLClassDiagram and EntityRelationshipDiagram (if necessary).
